### PR TITLE
Add QUIET var to pgbouncer to avoid logging db password

### DIFF
--- a/django-celery/templates/deployment.yaml
+++ b/django-celery/templates/deployment.yaml
@@ -140,6 +140,8 @@ spec:
             value: "{{ .Values.deployment.pgBouncer.maxDBConnections }}"
           - name: LISTEN_BACKLOG
             value: "{{ .Values.deployment.pgBouncer.listenBacklog }}"
+          - name: QUIET
+            value: "true"
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: {{ .Values.deployment.pgBouncer.port }}

--- a/nginx-uwsgi/templates/deployment.yaml
+++ b/nginx-uwsgi/templates/deployment.yaml
@@ -154,6 +154,8 @@ spec:
             value: "{{ .Values.deployment.pgBouncer.maxDBConnections }}"
           - name: LISTEN_BACKLOG
             value: "{{ .Values.deployment.pgBouncer.listenBacklog }}"
+          - name: QUIET
+            value: "true"
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: {{ .Values.deployment.pgBouncer.port }}

--- a/uwsgi/templates/deployment.yaml
+++ b/uwsgi/templates/deployment.yaml
@@ -152,6 +152,8 @@ spec:
             value: "{{ .Values.deployment.pgBouncer.maxDBConnections }}"
           - name: LISTEN_BACKLOG
             value: "{{ .Values.deployment.pgBouncer.listenBacklog }}"
+          - name: QUIET
+            value: "true"
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: {{ .Values.deployment.pgBouncer.port }}


### PR DESCRIPTION
When the pgbouncer container runs it logs the database password. Adding this parameter, logging the config file is skipped, hence, the database password. Related issue: https://github.com/brainsam/pgbouncer/issues/15